### PR TITLE
Cater for string Attachment IDs

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -63,8 +63,8 @@ type Attachment struct {
 	Color    string `json:"color,omitempty"`
 	Fallback string `json:"fallback,omitempty"`
 
-	CallbackID string `json:"callback_id,omitempty"`
-	ID         int    `json:"id,omitempty"`
+	CallbackID string       `json:"callback_id,omitempty"`
+	ID         AttachmentID `json:"id,omitempty"`
 
 	AuthorID      string `json:"author_id,omitempty"`
 	AuthorName    string `json:"author_name,omitempty"`

--- a/attachments_x.go
+++ b/attachments_x.go
@@ -40,13 +40,13 @@ func (a *AttachmentID) MarshalJSON() ([]byte, error) {
 	if len(*a) == 0 {
 		return []byte("null"), nil
 	}
-	if (*a)[len(*a)-1] == '$' {
+	if (*a)[len(*a)-1] == '$' && len(*a) > 1 {
 		// attempt to convert to integer
 		var n int64
-		if _, err := fmt.Sscanf(string(*a), "%d$", &n); err != nil {
-			return nil, err
+		if _, err := fmt.Sscanf(string(*a), "%d$", &n); err == nil {
+			return json.Marshal(n)
 		}
-		return json.Marshal(n)
+		// if it fails, return as string
 	}
 	// otherwise, return as string
 	return json.Marshal(string(*a))

--- a/attachments_x.go
+++ b/attachments_x.go
@@ -1,0 +1,53 @@
+package slack
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Slackdump extensions.
+
+type AttachmentID string
+
+func (a *AttachmentID) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	if data[0] == '"' && data[len(data)-1] == '"' {
+		var ret string
+		if err := json.Unmarshal(data, &ret); err != nil {
+			return err
+		}
+		*a = AttachmentID(ret)
+		return nil
+	} else if data[0]-'0' <= 9 {
+		var n int64
+		if err := json.Unmarshal(data, &n); err != nil {
+			return err
+		}
+		*a = AttachmentID(strconv.FormatInt(n, 10) + "$")
+		return nil
+	}
+	return fmt.Errorf("invalid AttachmentID: %s", string(data))
+}
+
+func (a *AttachmentID) MarshalJSON() ([]byte, error) {
+	if a == nil {
+		return nil, nil
+	}
+	if len(*a) == 0 {
+		return []byte("null"), nil
+	}
+	if (*a)[len(*a)-1] == '$' {
+		// attempt to convert to integer
+		var n int64
+		if _, err := fmt.Sscanf(string(*a), "%d$", &n); err != nil {
+			return nil, err
+		}
+		return json.Marshal(n)
+	}
+	// otherwise, return as string
+	return json.Marshal(string(*a))
+}

--- a/attachments_x_test.go
+++ b/attachments_x_test.go
@@ -1,0 +1,112 @@
+package slack
+
+import (
+	"reflect"
+	"testing"
+)
+
+func attachmentIDPtr(s string) *AttachmentID {
+	id := AttachmentID(s)
+	return &id
+}
+
+func TestAttachmentID_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		a       *AttachmentID
+		args    args
+		want    *AttachmentID
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			a:    new(AttachmentID),
+			args: args{
+				data: []byte(""),
+			},
+			want:    new(AttachmentID),
+			wantErr: false,
+		},
+		{
+			name: "string",
+			a:    new(AttachmentID),
+			args: args{
+				data: []byte(`"1234567890"`),
+			},
+			want:    attachmentIDPtr("1234567890"),
+			wantErr: false,
+		},
+		{
+			name: "integer",
+			a:    new(AttachmentID),
+			args: args{
+				data: []byte(`1234567890`),
+			},
+			want:    attachmentIDPtr("1234567890$"),
+			wantErr: false,
+		},
+		{
+			name: "invalid",
+			a:    new(AttachmentID),
+			args: args{
+				data: []byte(`{}`),
+			},
+			want:    new(AttachmentID),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.a.UnmarshalJSON(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("AttachmentID.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(tt.a, tt.want) {
+				t.Errorf("AttachmentID.UnmarshalJSON() = %v, want %v", tt.a, tt.want)
+			}
+		})
+	}
+}
+
+func TestAttachmentID_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       *AttachmentID
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			a:       new(AttachmentID),
+			want:    []byte("null"),
+			wantErr: false,
+		},
+		{
+			name:    "string",
+			a:       attachmentIDPtr("1234567890"),
+			want:    []byte(`"1234567890"`),
+			wantErr: false,
+		},
+		{
+			name:    "integer",
+			a:       attachmentIDPtr("1234567890$"),
+			want:    []byte(`1234567890`),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.a.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AttachmentID.MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AttachmentID.MarshalJSON() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/attachments_x_test.go
+++ b/attachments_x_test.go
@@ -96,6 +96,18 @@ func TestAttachmentID_MarshalJSON(t *testing.T) {
 			want:    []byte(`1234567890`),
 			wantErr: false,
 		},
+		{
+			name:    "just $",
+			a:       attachmentIDPtr("$"),
+			want:    []byte(`"$"`),
+			wantErr: false,
+		},
+		{
+			name:    "a string ending with $",
+			a:       attachmentIDPtr("have some $"),
+			want:    []byte(`"have some $"`),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- **allow strings and integers for attachment IDs**
- **edge cases**

